### PR TITLE
a number of corrections to changelog across the site

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -44,5 +44,6 @@
 * [FAQ](FAQ/README.md)
 	* [Ways to integrate](FAQ/ways-to-integrate.md)
 * [Changelog](changelog/README.md)
+	* [Changelog 2022](changelog/changelog2022.md)
 	* [Changelog 2021](changelog/changelog2021.md)
 	* [Changelog 2020](changelog/changelog2020.md)

--- a/booking-engine-api/README.md
+++ b/booking-engine-api/README.md
@@ -3,11 +3,10 @@
 The __Mews Booking Engine API__ is a web API that allows external applications such as booking widgets to interact programmatically with Mews to get information about offered rooms or spaces for a given property, to check availability of those rooms or spaces, and to create reservations.
 Use this option if you want to create your own custom booking engine.
 
-## OpenAPI definition
-> The Swagger/OpenAPI definition for the Mews Booking Engine API can be found [here](https://api.mews.com/swagger/distributor/swagger.json), you can use this to build out client applications using third party tools. At this stage we consider this a Beta test version, but please use it and get in touch to let us know how you get on.
+> ### OpenAPI definition
+> The Swagger/OpenAPI definition for the __Mews Booking Engine API__ can be found [here](https://api.mews.com/swagger/distributor/swagger.json), you can use this to build out client applications using third party tools. At this stage we consider this a Beta test version, but please use it and get in touch to let us know how you get on.
 
 * [Guidelines](guidelines/README.md)
 * [Use cases](use-cases/README.md)
 * [API Operations](operations/README.md)
-* [Changelog](changelog/README.md)
 * [Deprecations](deprecations/README.md)

--- a/booking-engine-standalone/README.md
+++ b/booking-engine-standalone/README.md
@@ -6,4 +6,3 @@ This section describes how to use it.
 
 * [Getting started](getting-started.md)
 * [Deeplinks](deeplinks.md)
-* [Changelog](changelog/README.md)

--- a/booking-engine-standalone/deeplinks.md
+++ b/booking-engine-standalone/deeplinks.md
@@ -19,7 +19,7 @@ This is the list of parameters that can be added to the URL query string. Parame
 | mewsEnd         | a departure date in ISO 8601 format \(`YYYY-MM-DD`\)                                            | `2023-01-23` for January 23, 2023                                            |
 | mewsVoucherCode | a voucher code                                                                                  | `E1A71167851A30043B12`                                                       |
 | mewsRoute       | [mewsRoute](#mewsroute)                                                                         | `rooms` for rooms step                                                       |
-| mewsSort        | sort categories on category step by lowest/highest price (Overrides all other ordering methods) | `mewsSort=asc` sorts by lowest price, `mewsSort=desc` sorts by highest price |
+| mewsSort        | sort categories on category step by lowest/highest price; overrides all other ordering methods  | `mewsSort=asc` sorts by lowest price, `mewsSort=desc` sorts by highest price |
 | mewsRoom        | opens with specified room selected \(`aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`\)                   | `da394bbb-9685-4bb8-9547-ab7300915967`                                       |
 | mewsAdultCount  | number of adults that should be selected by default                                             | `3`                                                                          |
 | mewsChildCount  | number of children that should be selected by default                                           | `1`                                                                          |

--- a/booking-engine-widget/README.md
+++ b/booking-engine-widget/README.md
@@ -9,4 +9,3 @@ It's a more advanced way of integrating the Mews Booking Engine into your websit
 * [Reference](reference.md)
 * [Integrations](integrations/README.md)
 * [Troubleshooting](troubleshooting.md)
-* [Changelog](changelog/README.md)

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,53 +1,11 @@
 # Changelog
 
 ## 26th January 2023
-* Standalone: Changed domain from api.mews.com to app.mews.com
-* Added new deeplink parameter [mewsSort](../booking-engine-standalone/deeplinks.md#parameters-supported-in-single-and-multi-enterprise-mode) for sorting categories by price
-* 
-## 13rd December 2022
-* Added [OpenAPI definition](../booking-engine-api/README.md#openapi-definition)
-
-## 9th November 2022
-* Changed [SettlementValue](../booking-engine-api/operations/hotels.md#rate-group) to optional field and added `SettlementFlatValue` property of absolute settlement amount
-
-## 25th October 2022
-* Added new [Google Analytics 4](../booking-engine-widget/integrations/google-triggers-reference.md#google-analytics-4-ga4-events) documentation
-* Enhanced [Google Tag Manager (GTM)](../booking-engine-widget/integrations/google-tag-manager.md#google-tag-manager-gtm) documentation
-
-## 20th October 2022
-
-* Added new operation [Get services availability](../booking-engine-api/operations/services.md#get-services-availability)
-* Added new operation [Get services pricing](../booking-engine-api/operations/services.md#get-services-pricing)
-
-## 19th October 2022
-
-* Added new operation [Get reservation price](../booking-engine-api/operations/reservations.md#get-reservation-price)
-
-## 1st July 2022
-
-* Added new operation [Get availability blocks](../booking-engine-api/operations/availability-blocks.md#get-availability-blocks)
-* `AvailabilityBlockId` property added to [Get availability](../booking-engine-api/operations/hotels.md#get-availability), [Create reservation groups](../booking-engine-api/operations/reservation-groups.md#create-reservation-groups) and [Get reservation pricing](../booking-engine-api/operations/reservations.md#get-reservation-pricing)
-* Added new [Availability Blocks Use Case](../booking-engine-api/use-cases/availability-blocks.md)
-* Added new [Supported currency codes](../booking-engine-api/guidelines/supported-currency-codes.md) documentation.
-* Added new [Supported language codes](../booking-engine-api/guidelines/supported-language-codes.md) documentation.
-
-## 7th June 2022
-
-* Launch of __Mews Booking Engine Guide__ at new URL [https://mews-systems.gitbook.io/booking-engine-guide/](https://mews-systems.gitbook.io/booking-engine-guide/), based on the old Distributor Guide
-  * Entire documentation re-structured and re-worded, for improved navigation and readability, and for consistency with other Mews APIs
-  * Product re-branded from 'Distributor' to 'Mews Booking Engine'
-  * No changes to API functionality
-
-## 28th March 2022
-
-* API: Password for test environment changed to _Distributor-api1_
-
-## 18th January 2022
-
-* Widget: Introduced new API methods to Distributor instance: [`setAdultCount`](../booking-engine-widget/reference.md) and [`setChildCount`](../booking-engine-widget/reference.md).
-* Standalone: Introduced new deeplinks `mewsAdultCount` and `mewsChildCount` to set initial occupancy.
+* Standalone: Changed domain from `api.mews.com` to `app.mews.com`
+* Standalone: Added new deeplink parameter [mewsSort](../booking-engine-standalone/deeplinks.md#parameters-supported-in-single-and-multi-enterprise-mode) for sorting categories by price
 
 | Changelog by year |
 | :-- |
+| [Changelog 2022](changelog2022.md) |
 | [Changelog 2021](changelog2021.md) |
 | [Changelog 2020](changelog2020.md) |

--- a/changelog/changelog2022.md
+++ b/changelog/changelog2022.md
@@ -1,0 +1,49 @@
+# Changelog
+
+## 13th December 2022
+* API: Added [OpenAPI definition](../booking-engine-api/README.md#openapi-definition)
+
+## 9th November 2022
+* API: Changed [SettlementValue](../booking-engine-api/operations/hotels.md#rate-group) to optional field and added `SettlementFlatValue` property of absolute settlement amount
+
+## 25th October 2022
+* Widget: Added new [Google Analytics 4](../booking-engine-widget/integrations/google-triggers-reference.md#google-analytics-4-ga4-events) documentation
+* Widget: Enhanced [Google Tag Manager (GTM)](../booking-engine-widget/integrations/google-tag-manager.md#google-tag-manager-gtm) documentation
+
+## 20th October 2022
+
+* API: Added new operation [Get services availability](../booking-engine-api/operations/services.md#get-services-availability)
+* API: Added new operation [Get services pricing](../booking-engine-api/operations/services.md#get-services-pricing)
+
+## 19th October 2022
+
+* API: Added new operation [Get reservation price](../booking-engine-api/operations/reservations.md#get-reservation-price)
+
+## 1st July 2022
+
+* API: Added new operation [Get availability blocks](../booking-engine-api/operations/availability-blocks.md#get-availability-blocks)
+* API: `AvailabilityBlockId` property added to [Get availability](../booking-engine-api/operations/hotels.md#get-availability), [Create reservation groups](../booking-engine-api/operations/reservation-groups.md#create-reservation-groups) and [Get reservation pricing](../booking-engine-api/operations/reservations.md#get-reservation-pricing)
+* API: Added new [Availability Blocks Use Case](../booking-engine-api/use-cases/availability-blocks.md)
+* API: Added new [Supported currency codes](../booking-engine-api/guidelines/supported-currency-codes.md) documentation.
+* API: Added new [Supported language codes](../booking-engine-api/guidelines/supported-language-codes.md) documentation.
+
+## 7th June 2022
+
+* General: Launch of __Mews Booking Engine Guide__ at new URL [https://mews-systems.gitbook.io/booking-engine-guide/](https://mews-systems.gitbook.io/booking-engine-guide/), based on the old Distributor Guide
+  * Entire documentation re-structured and re-worded, for improved navigation and readability, and for consistency with other Mews APIs
+  * Product re-branded from 'Distributor' to 'Mews Booking Engine'
+  * No changes to API functionality
+
+## 28th March 2022
+
+* API: Password for test environment changed to _Distributor-api1_
+
+## 18th January 2022
+
+* Widget: Introduced new API methods to Distributor instance: [`setAdultCount`](../booking-engine-widget/reference.md) and [`setChildCount`](../booking-engine-widget/reference.md).
+* Standalone: Introduced new deeplinks `mewsAdultCount` and `mewsChildCount` to set initial occupancy.
+
+| Changelog by year |
+| :-- |
+| [Changelog 2021](changelog2021.md) |
+| [Changelog 2020](changelog2020.md) |


### PR DESCRIPTION
#### Changelog notes 

```
* Note these changes are corrections to the changelog itself and do not need an entry in the changelog, if that makes sense
* Removed bogus '*'
* Corrected Dec date from 'rd' to 'th'
* Separated out 2022 changelog into separate file
* Removed invalid changelog links from home pages for Standalone, Widget & API
* Added "API:", "Widget:", etc. prefix to all changelog entries in 2022 and 2023
* Small correction to presentation of 'OpenAPI definition' on API home page
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
