### PR TITLE
updated CODEOWNERS - Public booking engine API goes under connectivity team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# GX team is a default owner of whole codebase. Any file without specific ownership will fallback to them.
+*                               @MewsSystems/tech-fe-bookingengine-owners
+
+# Public Booking Engine API documentation falls under Connectivity
+/booking-engine-api             @MewsSystems/tech-fe-connectivity-owners


### PR DESCRIPTION
#### Changelog notes 

 Public Booking Engine API documentation falls under Connectivity

