### PR TITLE
CON-8468: Document OccupancyData in services/getPricing

### DIFF
--- a/booking-engine-api/operations/services.md
+++ b/booking-engine-api/operations/services.md
@@ -93,7 +93,17 @@ Get pricing for the specified service for each time unit in the specified date i
     "CategoryIds": ["4037c0ec-a59d-43f1-9d97-d6c984764e8c"],
     "RateIds": ["4037c0ec-a59d-43f1-9d97-d6c984764e8c"],
     "LanguageCode": "en-GB",
-    "CurrencyCode": "EUR"
+    "CurrencyCode": "EUR",
+    "OccupancyData": [
+        {
+            "AgeCategoryId": "16e8a466-729e-4d32-a221-ade300e410a8",
+            "PersonCount": 1
+        },
+        {
+            "AgeCategoryId": "790c82c1-cbe6-4b8d-a45f-ade300e410a8",
+            "PersonCount": 1
+        }
+    ]
 }
 ```
 
@@ -108,6 +118,7 @@ Get pricing for the specified service for each time unit in the specified date i
 | `RateIds` | array of string | optional | Unique identifiers of specific rates for which pricing should be computed. If omitted, pricing will be computed and returned for all rates. |
 | `LanguageCode` | string | optional | Code of the language. [Supported language codes](../guidelines/supported-language-codes.md)  |
 | `CurrencyCode` | string | optional | Currency code which should be used for prices in the response. [Supported currency codes](../guidelines/supported-currency-codes.md)  |
+| `OccupancyData` | array of [Occupancy Data](hotels.md#occupancy-data) | optional | List of occupancy data. |
 
 ### Response
 
@@ -150,11 +161,11 @@ Get pricing for the specified service for each time unit in the specified date i
           "Occupancies": [
             {
               "AgeCategoryId": "16e8a466-729e-4d32-a221-ade300e410a8",
-              "PersonCount": 2
+              "PersonCount": 1
             },
             {
               "AgeCategoryId": "790c82c1-cbe6-4b8d-a45f-ade300e410a8",
-              "PersonCount": 0
+              "PersonCount": 1
             }
           ]
         }
@@ -275,11 +286,11 @@ Get pricing for the specified service for each time unit in the specified date i
 | `Rates` | array of [Rate](hotels.md#rate) | required | Information about all available rates. |
 | `CategoryPrices` | array of [Category price](#category-price) | required | Prices for all specified categories. |
 
-#### Category price 
+#### Category price
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `CategoryId` | string | required | Unique identifier of category. |
-| `OccupancyPrices` | array of objects with arrays of [Occupancy](#occupancy) | required | List of occupancies for age categories against which rate group prices are supplied. |
+| `OccupancyPrices` | array of objects with arrays of [Occupancy](#occupancy) | required | List of occupancies for age categories against which rate group prices are supplied. When `OccupancyData` request parameter is not provided, the prices for the combination of the default adult and a single child category is generated for up to 3 person counts. |
 | `RateGroupPrices` | array of [Rate group price](#rate-group-price) | required | Prices for the given category for each of the occupancy bands specified in OccupancyPrices. |
 
 #### Occupancy

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 29th August 2025
+* API: [Get services pricing](../booking-engine-api/operations/services.md#get-services-pricing)
+  * Added `OccupancyData` request parameter.
+  * Clarified the default behavior of `OccupancyPrices` property in [Category price](../booking-engine-api/operations/services.md#category-price) response object. Documentation-only, no change to the API.
+
 ## 16th July 2025
 * API: [Get promoted services](../booking-engine-api/operations/services.md#get-promoted-services)
   * Added new operation (restricted).


### PR DESCRIPTION
### Summary

Add OccupancyData + clarify OccupancyPrices in `services/getPricing`.

### Checklist (general)

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] Changelog dated the day when PR merged
- [ ] Changelog accurately describes all changes
- [ ] All hyperlinks tested
- [ ] SUMMARY.md updated if new pages added

### Checklist (API)

- [x] JSON examples updated
- [x] Properties in JSON examples in same order as in property tables
- [x] Changelog highlights the affected endpoints or operations
- [ ] Changelog highlights any deprecations
- [ ] Deprecation Table updated if any deprecations
